### PR TITLE
Add entry on create file action menu.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -29,6 +29,9 @@ Updates to support more constructs in capnp
           <keyboard-shortcut first-keystroke="control alt A" second-keystroke="G" keymap="$default"/>
           <add-to-group group-id="ToolsMenu" anchor="first" />
       </action>
+      <action id="Capnp.New" class="com.sercapnp.actions.NewFileAction" text="Capnp File" description="Create new Capnp file">
+          <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFromTemplate"/>
+      </action>
   </actions>
 
 </idea-plugin>

--- a/src/com/sercapnp/actions/NewFileAction.java
+++ b/src/com/sercapnp/actions/NewFileAction.java
@@ -1,0 +1,20 @@
+package com.sercapnp.actions;
+
+import com.intellij.ide.actions.CreateFileAction;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.project.DumbAware;
+import com.sercapnp.lang.CapnpFileType;
+
+public class NewFileAction extends CreateFileAction implements DumbAware {
+    static final FileType FILE_TYPE = CapnpFileType.INSTANCE;
+    static final String SUFFIX = "." + FILE_TYPE.getDefaultExtension().toLowerCase();
+
+    @Override
+    protected String getFileName(String newName) {
+        return newName.endsWith(SUFFIX) ? newName : newName + SUFFIX;
+    }
+
+    public NewFileAction() {
+        super(FILE_TYPE.getName(), "", null);
+    }
+}


### PR DESCRIPTION
Adds support for creating a new Capnp file from the new file menu. This saves the need to type the `.capnp` file extension.