### PR TITLE
Don't update plugin.xml since-build when compiling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,9 @@ dependencies {
 
 intellij {
     version '2018.2.1'
+    intellij.updateSinceUntilBuild false
 }
+
 patchPluginXml {
     changeNotes """
       <h1>Changelog</h1>


### PR DESCRIPTION
Hi @xmonader,

I decided to do some triage myself and thanks to https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000152064-plugin-is-incompatible-with-this-installation-, found the answer.  When compiling the generated `plugin.xml` file was being changed such that 2018.3 wasn't valid with the plugin.

This is tested locally as working.

Thanks for this plugin!

Closes #6