### PR TITLE
Support parentheses

### DIFF
--- a/src/main/java/com/sercapnp/lang/Capnp.flex
+++ b/src/main/java/com/sercapnp/lang/Capnp.flex
@@ -59,6 +59,8 @@ IDENTIFIER = [A-Za-z_][A-Za-z_0-9]*
     "}"                                             { return CapnpTypes.RIGHT_BRACE; }
     "["                                             { return CapnpTypes.LEFT_BRACKET; }
     "]"                                             { return CapnpTypes.RIGHT_BRACKET; }
+    "("                                             { return CapnpTypes.LEFT_PAREN; }
+    ")"                                             { return CapnpTypes.RIGHT_PAREN; }
 
     ({WHITE_SPACE})+                                { return TokenType.WHITE_SPACE; }
     [^]                                             { return TokenType.BAD_CHARACTER; }

--- a/src/main/java/com/sercapnp/lang/CapnpTypes.java
+++ b/src/main/java/com/sercapnp/lang/CapnpTypes.java
@@ -17,6 +17,8 @@ public interface CapnpTypes {
     IElementType RIGHT_BRACE = new CapnpTokenType("RIGHT_BRACE");
     IElementType LEFT_BRACKET = new CapnpTokenType("LEFT_BRACKET");
     IElementType RIGHT_BRACKET = new CapnpTokenType("RIGHT_BRACKET");
+    IElementType LEFT_PAREN  = new CapnpTokenType("LEFT_PAREN");
+    IElementType RIGHT_PAREN = new CapnpTokenType("RIGHT_PAREN");
 }
 
 


### PR DESCRIPTION
List syntax was not fully supported:

<img width="349" alt="image" src="https://github.com/user-attachments/assets/f8681b33-a095-427e-a9dd-971818e11af9" />

This allows opening and closed parentheses:

<img width="349" alt="image" src="https://github.com/user-attachments/assets/02b8bf3e-99c2-4639-a1ad-3e68e64b6299" />
