### PR TITLE
V4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'xmonader'
-version '3.0'
+version '4.1'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/src/main/java/com/sercapnp/actions/ShiftOrdinalsAction.java
+++ b/src/main/java/com/sercapnp/actions/ShiftOrdinalsAction.java
@@ -1,0 +1,412 @@
+package com.sercapnp.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Shifts ordinals down (increments) to create a gap for inserting a new field.
+ *
+ * Usage:
+ *   1. Place cursor on the line with @N (the field AFTER which you want to insert)
+ *   2. Invoke via Ctrl+Alt+A, S (or menu: Tools → Shift Ordinals Down)
+ *   3. All ordinals > N within the same struct scope are incremented by 1
+ *   4. @(N+1) is now free — type your new field with that ordinal
+ *
+ * Scope rules (per Cap'n Proto spec):
+ *   - union {} and group {} share the parent struct's ordinal space → INCLUDED
+ *   - Nested struct/enum/interface have their OWN ordinal space → SKIPPED
+ */
+public class ShiftOrdinalsAction extends AnAction {
+
+    // Matches @N where N is a decimal number (not @0x... hex IDs)
+    private static final Pattern ORDINAL_PATTERN = Pattern.compile("@(\\d+)");
+
+    // Matches the keyword before a { to determine block type
+    private static final Pattern BLOCK_KEYWORD_PATTERN = Pattern.compile(
+            "(struct|enum|interface|union|group)\\s+\\w*\\s*(?:\\([^)]*\\))?\\s*(?:@0x[a-fA-F0-9]+)?\\s*$"
+    );
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        Project project = e.getData(CommonDataKeys.PROJECT);
+        if (editor == null || project == null) return;
+
+        Document document = editor.getDocument();
+        String text = document.getText();
+        int caretOffset = editor.getCaretModel().getOffset();
+
+        // 1. Find the ordinal on the current line
+        int lineNumber = document.getLineNumber(caretOffset);
+        int lineStart = document.getLineStartOffset(lineNumber);
+        int lineEnd = document.getLineEndOffset(lineNumber);
+        String lineText = text.substring(lineStart, lineEnd);
+
+        Matcher lineMatcher = ORDINAL_PATTERN.matcher(lineText);
+        if (!lineMatcher.find()) {
+            Messages.showInfoMessage(project,
+                    "No ordinal (@N) found on the current line.\n" +
+                    "Place your cursor on the line with the ordinal after which you want to insert.",
+                    "Shift Ordinals");
+            return;
+        }
+
+        int threshold = Integer.parseInt(lineMatcher.group(1));
+
+        // 2. Find the enclosing struct scope
+        int[] scope = findEnclosingStructScope(text, caretOffset);
+        if (scope == null) {
+            Messages.showInfoMessage(project,
+                    "Could not find an enclosing struct scope.",
+                    "Shift Ordinals");
+            return;
+        }
+
+        int scopeStart = scope[0]; // Position of '{'
+        int scopeEnd = scope[1];   // Position of '}'
+
+        // 3. Collect all ordinal positions within scope that need shifting
+        //    Skip ordinals inside nested struct/enum/interface blocks
+        List<OrdinalHit> hits = collectOrdinalsInScope(text, scopeStart, scopeEnd, threshold);
+
+        if (hits.isEmpty()) {
+            Messages.showInfoMessage(project,
+                    "No ordinals found after @" + threshold + " to shift.",
+                    "Shift Ordinals");
+            return;
+        }
+
+        // 4. Apply replacements from end to start (preserves earlier offsets)
+        Collections.sort(hits, (a, b) -> Integer.compare(b.offset, a.offset));
+
+        com.intellij.openapi.vfs.VirtualFile vFile =
+                com.intellij.openapi.fileEditor.FileDocumentManager.getInstance().getFile(document);
+
+        WriteCommandAction.runWriteCommandAction(project, "Shift Ordinals Down", null, () -> {
+            for (OrdinalHit hit : hits) {
+                String replacement = "@" + (hit.value + 1);
+                document.replaceString(hit.offset, hit.offset + hit.length, replacement);
+            }
+        }, vFile != null ?
+                com.intellij.psi.PsiManager.getInstance(project).findFile(vFile) :
+                null);
+
+        // Show result
+        com.intellij.openapi.editor.EditorModificationUtil.scrollToCaret(editor);
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        // Only enable in .capnp files
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        boolean enabled = false;
+
+        if (editor != null) {
+            com.intellij.openapi.vfs.VirtualFile vFile =
+                    com.intellij.openapi.fileEditor.FileDocumentManager.getInstance()
+                            .getFile(editor.getDocument());
+            if (vFile != null) {
+                enabled = vFile.getName().endsWith(".capnp");
+            }
+        }
+
+        e.getPresentation().setEnabledAndVisible(enabled);
+    }
+
+    // ── Scope detection ─────────────────────────────────────────────────────────
+
+    /**
+     * Find the enclosing struct's { } boundaries.
+     *
+     * Walks backwards from caretOffset, tracking brace depth.
+     * When hitting a '{' at depth 0, checks if the preceding keyword is:
+     *   - struct → found it, return [bracePos, matchingClose]
+     *   - union/group → continue walking (these share parent struct's ordinals)
+     *   - enum/interface → also valid top-level scope, return it
+     */
+    private int[] findEnclosingStructScope(String text, int caretOffset) {
+        int depth = 0;
+        boolean inString = false;
+        boolean inComment = false;
+
+        for (int i = caretOffset - 1; i >= 0; i--) {
+            char c = text.charAt(i);
+
+            // Reverse comment detection: if we hit \n, clear comment state
+            if (c == '\n') {
+                inComment = false;
+                continue;
+            }
+
+            if (inString) {
+                if (c == '"' && (i == 0 || text.charAt(i - 1) != '\\')) {
+                    inString = false;
+                }
+                continue;
+            }
+
+            // Check if this position is inside a comment
+            // (walk forward to check if there's a # before us on this line)
+            if (c == '#') {
+                inComment = true;
+                continue;
+            }
+            if (inComment) continue;
+
+            if (c == '"') {
+                inString = true;
+                continue;
+            }
+
+            if (c == '}') {
+                depth++;
+            } else if (c == '{') {
+                if (depth == 0) {
+                    // This '{' is our potential scope opener
+                    String blockType = getBlockType(text, i);
+
+                    if ("struct".equals(blockType) || "enum".equals(blockType)
+                            || "interface".equals(blockType)) {
+                        // Found our scope — find the matching '}'
+                        int closePos = findMatchingClose(text, i);
+                        if (closePos >= 0) {
+                            return new int[]{i, closePos};
+                        }
+                        return null;
+                    }
+
+                    // union/group → keep going, ordinals belong to the parent struct
+                    // (don't change depth — we're looking for the PARENT's '{')
+                    continue;
+                }
+                depth--;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Determine the keyword (struct/enum/interface/union/group) before a '{'.
+     */
+    private String getBlockType(String text, int bracePos) {
+        String before = text.substring(Math.max(0, bracePos - 200), bracePos).trim();
+        Matcher m = BLOCK_KEYWORD_PATTERN.matcher(before);
+        if (m.find()) {
+            return m.group(1);
+        }
+
+        // Fallback: check for anonymous union (just "union {")
+        if (before.endsWith("union")) return "union";
+        if (before.endsWith("group")) return "group";
+
+        // Check for simple patterns without identifiers
+        String trimmed = before.replaceAll("\\s+", " ").trim();
+        if (trimmed.endsWith("union")) return "union";
+
+        return null;
+    }
+
+    /**
+     * Find the matching '}' for a '{' at the given position.
+     */
+    private int findMatchingClose(String text, int openPos) {
+        int depth = 0;
+        boolean inString = false;
+        boolean inComment = false;
+
+        for (int i = openPos; i < text.length(); i++) {
+            char c = text.charAt(i);
+
+            if (inComment) {
+                if (c == '\n') inComment = false;
+                continue;
+            }
+            if (inString) {
+                if (c == '\\') { i++; continue; }
+                if (c == '"') inString = false;
+                continue;
+            }
+            if (c == '#') { inComment = true; continue; }
+            if (c == '"') { inString = true; continue; }
+
+            if (c == '{') depth++;
+            else if (c == '}') {
+                depth--;
+                if (depth == 0) return i;
+            }
+        }
+        return -1;
+    }
+
+    // ── Ordinal collection ──────────────────────────────────────────────────────
+
+    /**
+     * Collect all @N ordinals within [scopeStart, scopeEnd] where N > threshold.
+     *
+     * Skips ordinals inside nested struct/enum/interface blocks (they have
+     * independent ordinal spaces). Includes ordinals inside union/group
+     * (they share the parent struct's ordinal space).
+     */
+    private List<OrdinalHit> collectOrdinalsInScope(String text, int scopeStart,
+                                                     int scopeEnd, int threshold) {
+        List<OrdinalHit> hits = new ArrayList<>();
+
+        // Track which ranges to skip (nested struct/enum/interface bodies)
+        List<int[]> skipRanges = findNestedIndependentBlocks(text, scopeStart, scopeEnd);
+
+        // Scan for all @N in the scope
+        Matcher m = ORDINAL_PATTERN.matcher(text);
+        int searchStart = scopeStart + 1; // Skip the opening '{'
+
+        while (m.find(searchStart)) {
+            if (m.start() >= scopeEnd) break;
+
+            int ordinalValue = Integer.parseInt(m.group(1));
+            int matchStart = m.start();
+
+            // Skip if inside a nested struct/enum/interface
+            if (isInSkipRange(matchStart, skipRanges)) {
+                searchStart = m.end();
+                continue;
+            }
+
+            // Check this isn't a hex ID (@0x...)
+            // ORDINAL_PATTERN only matches @digits, but @0 followed by x would match @0
+            // The regex already handles this — @0x would match @0 then 'x' is after
+            // Double-check: if the character after the match is 'x' or 'X', skip
+            int afterMatch = m.end();
+            if (afterMatch < text.length() &&
+                    (text.charAt(afterMatch) == 'x' || text.charAt(afterMatch) == 'X')) {
+                searchStart = m.end();
+                continue;
+            }
+
+            if (ordinalValue > threshold) {
+                hits.add(new OrdinalHit(matchStart, m.end() - matchStart, ordinalValue));
+            }
+
+            searchStart = m.end();
+        }
+
+        return hits;
+    }
+
+    /**
+     * Find all nested struct/enum/interface block ranges that have independent
+     * ordinal spaces. These ranges will be skipped during ordinal shifting.
+     *
+     * union {} and group {} are NOT included — they share the parent's ordinals.
+     */
+    private List<int[]> findNestedIndependentBlocks(String text, int scopeStart, int scopeEnd) {
+        List<int[]> ranges = new ArrayList<>();
+
+        // We need to find nested struct/enum/interface definitions
+        // Pattern: (struct|enum|interface) Name ... {
+        Pattern nestedDef = Pattern.compile(
+                "\\b(struct|enum|interface)\\s+[A-Z][A-Za-z0-9]*\\s*(?:\\([^)]*\\))?\\s*(?:@0x[a-fA-F0-9]+)?\\s*\\{"
+        );
+
+        int depth = 0;
+        boolean inString = false;
+        boolean inComment = false;
+
+        // First pass: find the depth-1 struct/enum/interface blocks
+        // (depth 0 = the scope itself, depth 1 = direct children)
+        Matcher m = nestedDef.matcher(text);
+        int searchFrom = scopeStart + 1;
+
+        while (m.find(searchFrom)) {
+            int defStart = m.start();
+            if (defStart >= scopeEnd) break;
+
+            // Verify this isn't inside a string or comment
+            if (isInStringOrComment(text, scopeStart, defStart)) {
+                searchFrom = m.end();
+                continue;
+            }
+
+            // Find the '{' in this match
+            int bracePos = text.indexOf('{', m.start());
+            if (bracePos < 0 || bracePos >= scopeEnd) {
+                searchFrom = m.end();
+                continue;
+            }
+
+            // Find its matching '}'
+            int closePos = findMatchingClose(text, bracePos);
+            if (closePos > 0 && closePos <= scopeEnd) {
+                ranges.add(new int[]{bracePos, closePos});
+                searchFrom = closePos + 1;
+            } else {
+                searchFrom = m.end();
+            }
+        }
+
+        return ranges;
+    }
+
+    /**
+     * Check if a position falls within any of the skip ranges.
+     */
+    private boolean isInSkipRange(int pos, List<int[]> ranges) {
+        for (int[] range : ranges) {
+            if (pos > range[0] && pos < range[1]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Simple check if a position is inside a string or comment.
+     */
+    private boolean isInStringOrComment(String text, int from, int pos) {
+        boolean inString = false;
+        boolean inComment = false;
+
+        for (int i = from; i < pos && i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (inComment) {
+                if (c == '\n') inComment = false;
+                continue;
+            }
+            if (inString) {
+                if (c == '\\') { i++; continue; }
+                if (c == '"') inString = false;
+                continue;
+            }
+            if (c == '#') inComment = true;
+            else if (c == '"') inString = true;
+        }
+
+        return inString || inComment;
+    }
+
+    // ── Data class ──────────────────────────────────────────────────────────────
+
+    private static class OrdinalHit {
+        final int offset;   // Position of '@' in the document
+        final int length;   // Length of "@N" text
+        final int value;    // The ordinal number N
+
+        OrdinalHit(int offset, int length, int value) {
+            this.offset = offset;
+            this.length = length;
+            this.value = value;
+        }
+    }
+}

--- a/src/main/java/com/sercapnp/actions/UnshiftOrdinalsAction.java
+++ b/src/main/java/com/sercapnp/actions/UnshiftOrdinalsAction.java
@@ -1,0 +1,304 @@
+package com.sercapnp.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Shifts ordinals up (decrements) to close a gap left by a removed field.
+ *
+ * Usage:
+ *   1. Remove the field (e.g., delete the line with @5)
+ *   2. Place cursor on the first line AFTER the gap (the line with @6)
+ *   3. Invoke via Ctrl+Alt+A, U (or menu: Tools → Shift Ordinals Up)
+ *   4. All ordinals >= 6 within the same struct scope are decremented by 1
+ *   5. Result: @6→@5, @7→@6, ..., @45→@44
+ *
+ * Scope rules (per Cap'n Proto spec):
+ *   - union {} and group {} share the parent struct's ordinal space → INCLUDED
+ *   - Nested struct/enum/interface have their OWN ordinal space → SKIPPED
+ */
+public class UnshiftOrdinalsAction extends AnAction {
+
+    private static final Pattern ORDINAL_PATTERN = Pattern.compile("@(\\d+)");
+
+    private static final Pattern BLOCK_KEYWORD_PATTERN = Pattern.compile(
+            "(struct|enum|interface|union|group)\\s+\\w*\\s*(?:\\([^)]*\\))?\\s*(?:@0x[a-fA-F0-9]+)?\\s*$"
+    );
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        Project project = e.getData(CommonDataKeys.PROJECT);
+        if (editor == null || project == null) return;
+
+        Document document = editor.getDocument();
+        String text = document.getText();
+        int caretOffset = editor.getCaretModel().getOffset();
+
+        // 1. Find the ordinal on the current line
+        int lineNumber = document.getLineNumber(caretOffset);
+        int lineStart = document.getLineStartOffset(lineNumber);
+        int lineEnd = document.getLineEndOffset(lineNumber);
+        String lineText = text.substring(lineStart, lineEnd);
+
+        Matcher lineMatcher = ORDINAL_PATTERN.matcher(lineText);
+        if (!lineMatcher.find()) {
+            Messages.showInfoMessage(project,
+                    "No ordinal (@N) found on the current line.\n" +
+                    "Place your cursor on the first line after the removed field.",
+                    "Shift Ordinals Up");
+            return;
+        }
+
+        int threshold = Integer.parseInt(lineMatcher.group(1));
+
+        if (threshold == 0) {
+            Messages.showInfoMessage(project,
+                    "Cannot shift @0 — it is already the first ordinal.",
+                    "Shift Ordinals Up");
+            return;
+        }
+
+        // 2. Find the enclosing struct scope
+        int[] scope = findEnclosingStructScope(text, caretOffset);
+        if (scope == null) {
+            Messages.showInfoMessage(project,
+                    "Could not find an enclosing struct scope.",
+                    "Shift Ordinals Up");
+            return;
+        }
+
+        int scopeStart = scope[0];
+        int scopeEnd = scope[1];
+
+        // 3. Collect ordinals >= threshold that need shifting
+        List<OrdinalHit> hits = collectOrdinalsInScope(text, scopeStart, scopeEnd, threshold);
+
+        if (hits.isEmpty()) {
+            Messages.showInfoMessage(project,
+                    "No ordinals found at or after @" + threshold + " to shift.",
+                    "Shift Ordinals Up");
+            return;
+        }
+
+        // 4. Apply replacements from end to start
+        Collections.sort(hits, (a, b) -> Integer.compare(b.offset, a.offset));
+
+        com.intellij.openapi.vfs.VirtualFile vFile =
+                com.intellij.openapi.fileEditor.FileDocumentManager.getInstance().getFile(document);
+
+        WriteCommandAction.runWriteCommandAction(project, "Shift Ordinals Up", null, () -> {
+            for (OrdinalHit hit : hits) {
+                String replacement = "@" + (hit.value - 1);
+                document.replaceString(hit.offset, hit.offset + hit.length, replacement);
+            }
+        }, vFile != null ?
+                com.intellij.psi.PsiManager.getInstance(project).findFile(vFile) :
+                null);
+
+        com.intellij.openapi.editor.EditorModificationUtil.scrollToCaret(editor);
+    }
+
+    @Override
+    public void update(@NotNull AnActionEvent e) {
+        Editor editor = e.getData(CommonDataKeys.EDITOR);
+        boolean enabled = false;
+
+        if (editor != null) {
+            com.intellij.openapi.vfs.VirtualFile vFile =
+                    com.intellij.openapi.fileEditor.FileDocumentManager.getInstance()
+                            .getFile(editor.getDocument());
+            if (vFile != null) {
+                enabled = vFile.getName().endsWith(".capnp");
+            }
+        }
+
+        e.getPresentation().setEnabledAndVisible(enabled);
+    }
+
+    // ── Scope detection (same logic as ShiftOrdinalsAction) ──────────────────────
+
+    private int[] findEnclosingStructScope(String text, int caretOffset) {
+        int depth = 0;
+        boolean inString = false;
+        boolean inComment = false;
+
+        for (int i = caretOffset - 1; i >= 0; i--) {
+            char c = text.charAt(i);
+
+            if (c == '\n') { inComment = false; continue; }
+            if (inString) {
+                if (c == '"' && (i == 0 || text.charAt(i - 1) != '\\')) inString = false;
+                continue;
+            }
+            if (c == '#') { inComment = true; continue; }
+            if (inComment) continue;
+            if (c == '"') { inString = true; continue; }
+
+            if (c == '}') {
+                depth++;
+            } else if (c == '{') {
+                if (depth == 0) {
+                    String blockType = getBlockType(text, i);
+                    if ("struct".equals(blockType) || "enum".equals(blockType)
+                            || "interface".equals(blockType)) {
+                        int closePos = findMatchingClose(text, i);
+                        if (closePos >= 0) return new int[]{i, closePos};
+                        return null;
+                    }
+                    continue; // union/group — keep going up
+                }
+                depth--;
+            }
+        }
+        return null;
+    }
+
+    private String getBlockType(String text, int bracePos) {
+        String before = text.substring(Math.max(0, bracePos - 200), bracePos).trim();
+        Matcher m = BLOCK_KEYWORD_PATTERN.matcher(before);
+        if (m.find()) return m.group(1);
+        if (before.endsWith("union")) return "union";
+        if (before.endsWith("group")) return "group";
+        return null;
+    }
+
+    private int findMatchingClose(String text, int openPos) {
+        int depth = 0;
+        boolean inString = false;
+        boolean inComment = false;
+
+        for (int i = openPos; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (inComment) { if (c == '\n') inComment = false; continue; }
+            if (inString) {
+                if (c == '\\') { i++; continue; }
+                if (c == '"') inString = false;
+                continue;
+            }
+            if (c == '#') { inComment = true; continue; }
+            if (c == '"') { inString = true; continue; }
+            if (c == '{') depth++;
+            else if (c == '}') { depth--; if (depth == 0) return i; }
+        }
+        return -1;
+    }
+
+    // ── Ordinal collection ──────────────────────────────────────────────────────
+
+    /**
+     * Collect all @N ordinals within scope where N >= threshold.
+     * Skips nested struct/enum/interface blocks.
+     */
+    private List<OrdinalHit> collectOrdinalsInScope(String text, int scopeStart,
+                                                     int scopeEnd, int threshold) {
+        List<OrdinalHit> hits = new ArrayList<>();
+        List<int[]> skipRanges = findNestedIndependentBlocks(text, scopeStart, scopeEnd);
+
+        Matcher m = ORDINAL_PATTERN.matcher(text);
+        int searchStart = scopeStart + 1;
+
+        while (m.find(searchStart)) {
+            if (m.start() >= scopeEnd) break;
+
+            int ordinalValue = Integer.parseInt(m.group(1));
+            int matchStart = m.start();
+
+            if (isInSkipRange(matchStart, skipRanges)) {
+                searchStart = m.end();
+                continue;
+            }
+
+            // Skip hex IDs
+            int afterMatch = m.end();
+            if (afterMatch < text.length() &&
+                    (text.charAt(afterMatch) == 'x' || text.charAt(afterMatch) == 'X')) {
+                searchStart = m.end();
+                continue;
+            }
+
+            if (ordinalValue >= threshold) {
+                hits.add(new OrdinalHit(matchStart, m.end() - matchStart, ordinalValue));
+            }
+
+            searchStart = m.end();
+        }
+        return hits;
+    }
+
+    private List<int[]> findNestedIndependentBlocks(String text, int scopeStart, int scopeEnd) {
+        List<int[]> ranges = new ArrayList<>();
+        Pattern nestedDef = Pattern.compile(
+                "\\b(struct|enum|interface)\\s+[A-Z][A-Za-z0-9]*\\s*(?:\\([^)]*\\))?\\s*(?:@0x[a-fA-F0-9]+)?\\s*\\{"
+        );
+        Matcher m = nestedDef.matcher(text);
+        int searchFrom = scopeStart + 1;
+
+        while (m.find(searchFrom)) {
+            int defStart = m.start();
+            if (defStart >= scopeEnd) break;
+            if (isInStringOrComment(text, scopeStart, defStart)) {
+                searchFrom = m.end();
+                continue;
+            }
+            int bracePos = text.indexOf('{', m.start());
+            if (bracePos < 0 || bracePos >= scopeEnd) { searchFrom = m.end(); continue; }
+            int closePos = findMatchingClose(text, bracePos);
+            if (closePos > 0 && closePos <= scopeEnd) {
+                ranges.add(new int[]{bracePos, closePos});
+                searchFrom = closePos + 1;
+            } else {
+                searchFrom = m.end();
+            }
+        }
+        return ranges;
+    }
+
+    private boolean isInSkipRange(int pos, List<int[]> ranges) {
+        for (int[] range : ranges) {
+            if (pos > range[0] && pos < range[1]) return true;
+        }
+        return false;
+    }
+
+    private boolean isInStringOrComment(String text, int from, int pos) {
+        boolean inString = false;
+        boolean inComment = false;
+        for (int i = from; i < pos && i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (inComment) { if (c == '\n') inComment = false; continue; }
+            if (inString) {
+                if (c == '\\') { i++; continue; }
+                if (c == '"') inString = false;
+                continue;
+            }
+            if (c == '#') inComment = true;
+            else if (c == '"') inString = true;
+        }
+        return inString || inComment;
+    }
+
+    private static class OrdinalHit {
+        final int offset;
+        final int length;
+        final int value;
+        OrdinalHit(int offset, int length, int value) {
+            this.offset = offset;
+            this.length = length;
+            this.value = value;
+        }
+    }
+}

--- a/src/main/java/com/sercapnp/lang/CapnpCompletionContributor.java
+++ b/src/main/java/com/sercapnp/lang/CapnpCompletionContributor.java
@@ -1,0 +1,344 @@
+package com.sercapnp.lang;
+
+import com.intellij.codeInsight.completion.*;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.ProcessingContext;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+/**
+ * Auto-completion for Cap'n Proto schema files.
+ *
+ * Context detection (by scanning backwards from caret):
+ *   ':' → built-in types + user/imported types
+ *   '=' → constant values
+ *   '$' → annotation names
+ *   top-level → declaration keywords
+ *   inside {} → body-level keywords
+ *   extends( → interface types
+ *   annotation name( → target list
+ *   List( / generic( → types
+ */
+public class CapnpCompletionContributor extends CompletionContributor {
+
+    private static final String[] BUILTIN_TYPES = {
+            "Void", "Bool",
+            "Int8", "Int16", "Int32", "Int64",
+            "UInt8", "UInt16", "UInt32", "UInt64",
+            "Float32", "Float64",
+            "Text", "Data",
+            "List", "AnyPointer"
+    };
+
+    private static final String[] TOP_LEVEL_KEYWORDS = {
+            "struct", "enum", "interface", "const", "using", "import", "annotation"
+    };
+
+    private static final String[] BODY_KEYWORDS = {
+            "union", "group", "struct", "enum", "interface", "const", "using"
+    };
+
+    private static final String[] ANNOTATION_TARGETS = {
+            "struct", "field", "union", "group", "enum", "enumerant",
+            "interface", "method", "param", "annotation", "const", "file", "*"
+    };
+
+    private static final String[] CONSTANT_VALUES = {
+            "true", "false", "void", "inf", "nan"
+    };
+
+    public CapnpCompletionContributor() {
+        extend(CompletionType.BASIC,
+                PlatformPatterns.psiElement().withLanguage(CapnpLanguage.INSTANCE),
+                new CompletionProvider<CompletionParameters>() {
+                    @Override
+                    protected void addCompletions(@NotNull CompletionParameters parameters,
+                                                  @NotNull ProcessingContext context,
+                                                  @NotNull CompletionResultSet result) {
+                        doAddCompletions(parameters, result);
+                    }
+                }
+        );
+    }
+
+    private void doAddCompletions(@NotNull CompletionParameters parameters,
+                                  @NotNull CompletionResultSet result) {
+        PsiFile file = parameters.getOriginalFile();
+        int offset = parameters.getOffset();
+        String fileText = file.getText();
+
+        ContextKind ctx = analyzeContext(fileText, offset);
+
+        switch (ctx) {
+            case TYPE_POSITION:
+                addBuiltinTypes(result);
+                addUserDefinedTypes(result, file);
+                break;
+            case TOP_LEVEL:
+                addKeywords(result, TOP_LEVEL_KEYWORDS, "keyword");
+                break;
+            case BODY_LEVEL:
+                addKeywords(result, BODY_KEYWORDS, "keyword");
+                break;
+            case ANNOTATION_TARGET:
+                addKeywords(result, ANNOTATION_TARGETS, "target");
+                break;
+            case VALUE_POSITION:
+                addKeywords(result, CONSTANT_VALUES, "constant");
+                addUserDefinedConstants(result, file);
+                break;
+            case ANNOTATION_REF:
+                addAnnotationNames(result, file);
+                break;
+            case EXTENDS_TYPE:
+                addBuiltinTypes(result);
+                addUserDefinedTypes(result, file);
+                break;
+            default:
+                addBuiltinTypes(result);
+                addKeywords(result, TOP_LEVEL_KEYWORDS, "keyword");
+                addUserDefinedTypes(result, file);
+                break;
+        }
+    }
+
+    // ── Context detection ───────────────────────────────────────────────────────
+
+    private enum ContextKind {
+        TYPE_POSITION, TOP_LEVEL, BODY_LEVEL, ANNOTATION_TARGET,
+        VALUE_POSITION, ANNOTATION_REF, EXTENDS_TYPE, GENERIC
+    }
+
+    private ContextKind analyzeContext(String text, int offset) {
+        int pos = Math.min(offset, text.length()) - 1;
+
+        // Skip whitespace and partial identifier backwards
+        // First skip the partial identifier the user is currently typing
+        while (pos >= 0 && (Character.isLetterOrDigit(text.charAt(pos)) || text.charAt(pos) == '_')) {
+            pos--;
+        }
+        // Then skip whitespace
+        while (pos >= 0 && Character.isWhitespace(text.charAt(pos))) {
+            pos--;
+        }
+
+        if (pos < 0) return ContextKind.TOP_LEVEL;
+
+        char prevChar = text.charAt(pos);
+
+        // After ':' → type position
+        if (prevChar == ':') return ContextKind.TYPE_POSITION;
+
+        // After '=' → value position
+        if (prevChar == '=') return ContextKind.VALUE_POSITION;
+
+        // After '$' → annotation reference
+        if (prevChar == '$') return ContextKind.ANNOTATION_REF;
+
+        // After '(' or ',' → check what kind of context
+        if (prevChar == '(' || prevChar == ',') {
+            String wordBefore = getWordBefore(text, pos - 1);
+            if ("extends".equals(wordBefore)) return ContextKind.EXTENDS_TYPE;
+            if ("List".equals(wordBefore)) return ContextKind.TYPE_POSITION;
+
+            // Check if inside annotation target list
+            if (prevChar == '(' && isAfterAnnotationDecl(text, pos)) {
+                return ContextKind.ANNOTATION_TARGET;
+            }
+            if (prevChar == ',' && isInAnnotationTargetList(text, pos)) {
+                return ContextKind.ANNOTATION_TARGET;
+            }
+
+            // If after '(' preceded by a capitalized name → likely generic param → type
+            if (wordBefore.length() > 0 && Character.isUpperCase(wordBefore.charAt(0))) {
+                return ContextKind.TYPE_POSITION;
+            }
+        }
+
+        int braceDepth = countBraceDepth(text, offset);
+
+        // After ';', '{', '}' → depends on depth
+        if (prevChar == ';' || prevChar == '{' || prevChar == '}') {
+            return braceDepth == 0 ? ContextKind.TOP_LEVEL : ContextKind.BODY_LEVEL;
+        }
+
+        // Line start
+        if (isAtLineStart(text, pos)) {
+            return braceDepth == 0 ? ContextKind.TOP_LEVEL : ContextKind.BODY_LEVEL;
+        }
+
+        // If inside braces, check if there's a preceding ':'
+        if (braceDepth > 0 && hasPrecedingColonOnStatement(text, pos)) {
+            return ContextKind.TYPE_POSITION;
+        }
+
+        return braceDepth > 0 ? ContextKind.BODY_LEVEL : ContextKind.GENERIC;
+    }
+
+    // ── Completion providers ────────────────────────────────────────────────────
+
+    private void addBuiltinTypes(@NotNull CompletionResultSet result) {
+        for (String type : BUILTIN_TYPES) {
+            LookupElementBuilder el = LookupElementBuilder.create(type)
+                    .withTypeText("built-in", true)
+                    .withBoldness(true);
+
+            if ("List".equals(type)) {
+                el = el.withTailText("(T)", true)
+                        .withInsertHandler((ctx, item) -> {
+                            ctx.getEditor().getDocument().insertString(ctx.getTailOffset(), "()");
+                            ctx.getEditor().getCaretModel().moveToOffset(ctx.getTailOffset() - 1);
+                        });
+            }
+
+            result.addElement(PrioritizedLookupElement.withPriority(el, 100));
+        }
+    }
+
+    private void addUserDefinedTypes(@NotNull CompletionResultSet result, PsiFile file) {
+        Set<String> types = CapnpSchemaScanner.collectVisibleTypes(file);
+        for (String type : types) {
+            // Skip built-in type names to avoid duplicates
+            boolean isBuiltin = false;
+            for (String bt : BUILTIN_TYPES) {
+                if (bt.equals(type)) { isBuiltin = true; break; }
+            }
+            if (isBuiltin) continue;
+
+            LookupElementBuilder el = LookupElementBuilder.create(type)
+                    .withTypeText("type", true);
+            result.addElement(PrioritizedLookupElement.withPriority(el, 80));
+        }
+    }
+
+    private void addKeywords(@NotNull CompletionResultSet result, String[] keywords, String typeText) {
+        for (String kw : keywords) {
+            LookupElementBuilder el = LookupElementBuilder.create(kw)
+                    .withTypeText(typeText, true)
+                    .withBoldness(true);
+
+            if ("struct".equals(kw) || "enum".equals(kw) || "interface".equals(kw)) {
+                el = el.withInsertHandler((ctx, item) -> {
+                    ctx.getEditor().getDocument().insertString(ctx.getTailOffset(), " ");
+                    ctx.getEditor().getCaretModel().moveToOffset(ctx.getTailOffset());
+                });
+            } else if ("import".equals(kw)) {
+                el = el.withInsertHandler((ctx, item) -> {
+                    ctx.getEditor().getDocument().insertString(ctx.getTailOffset(), " \"\";");
+                    ctx.getEditor().getCaretModel().moveToOffset(ctx.getTailOffset() - 2);
+                });
+            } else if ("const".equals(kw)) {
+                el = el.withInsertHandler((ctx, item) -> {
+                    ctx.getEditor().getDocument().insertString(ctx.getTailOffset(), " ");
+                    ctx.getEditor().getCaretModel().moveToOffset(ctx.getTailOffset());
+                });
+            }
+
+            result.addElement(PrioritizedLookupElement.withPriority(el, 90));
+        }
+    }
+
+    private void addUserDefinedConstants(@NotNull CompletionResultSet result, PsiFile file) {
+        CapnpSchemaScanner.ScanResult scan = CapnpSchemaScanner.scan(file.getText());
+        for (String c : scan.constants) {
+            LookupElementBuilder el = LookupElementBuilder.create("." + c)
+                    .withPresentableText("." + c)
+                    .withTypeText("const", true);
+            result.addElement(PrioritizedLookupElement.withPriority(el, 70));
+        }
+    }
+
+    private void addAnnotationNames(@NotNull CompletionResultSet result, PsiFile file) {
+        Set<String> annots = CapnpSchemaScanner.collectVisibleAnnotations(file);
+        for (String name : annots) {
+            LookupElementBuilder el = LookupElementBuilder.create(name)
+                    .withTypeText("annotation", true);
+            result.addElement(PrioritizedLookupElement.withPriority(el, 85));
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private int countBraceDepth(String text, int offset) {
+        int depth = 0;
+        boolean inString = false;
+        boolean inComment = false;
+
+        for (int i = 0; i < offset && i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (inComment) {
+                if (c == '\n') inComment = false;
+                continue;
+            }
+            if (inString) {
+                if (c == '\\') { i++; continue; }
+                if (c == '"') inString = false;
+                continue;
+            }
+            if (c == '#') { inComment = true; continue; }
+            if (c == '"') { inString = true; continue; }
+            if (c == '{') depth++;
+            if (c == '}') depth--;
+        }
+        return depth;
+    }
+
+    private String getWordBefore(String text, int pos) {
+        while (pos >= 0 && Character.isWhitespace(text.charAt(pos))) pos--;
+        if (pos < 0) return "";
+        int end = pos + 1;
+        while (pos >= 0 && Character.isLetterOrDigit(text.charAt(pos))) pos--;
+        return text.substring(pos + 1, end);
+    }
+
+    private boolean isAtLineStart(String text, int pos) {
+        while (pos >= 0 && (text.charAt(pos) == ' ' || text.charAt(pos) == '\t')) pos--;
+        return pos < 0 || text.charAt(pos) == '\n';
+    }
+
+    /**
+     * Check if position is right after 'annotation Name (' pattern.
+     */
+    private boolean isAfterAnnotationDecl(String text, int parenPos) {
+        // Go back from '(' to find the pattern: annotation <name> <optional-typeId>
+        String before = "";
+        int lineStart = text.lastIndexOf('\n', parenPos - 1) + 1;
+        if (parenPos > lineStart) {
+            before = text.substring(lineStart, parenPos).trim();
+        }
+        return before.matches(".*annotation\\s+[a-zA-Z][a-zA-Z0-9]*\\s*(?:@0x[a-fA-F0-9]+\\s*)?");
+    }
+
+    /**
+     * Check if we're inside an annotation target list by finding unmatched '('.
+     */
+    private boolean isInAnnotationTargetList(String text, int pos) {
+        int parenDepth = 0;
+        for (int i = pos; i >= 0; i--) {
+            char c = text.charAt(i);
+            if (c == ')') parenDepth++;
+            else if (c == '(') {
+                if (parenDepth == 0) return isAfterAnnotationDecl(text, i);
+                parenDepth--;
+            }
+            else if (c == '{' || c == '}') break;
+        }
+        return false;
+    }
+
+    /**
+     * Check if there's a ':' on the current statement (between last ';'/'{' and pos).
+     */
+    private boolean hasPrecedingColonOnStatement(String text, int pos) {
+        for (int i = pos; i >= 0; i--) {
+            char c = text.charAt(i);
+            if (c == ':') return true;
+            if (c == ';' || c == '{' || c == '}') return false;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/sercapnp/lang/CapnpGotoDeclarationHandler.java
+++ b/src/main/java/com/sercapnp/lang/CapnpGotoDeclarationHandler.java
@@ -1,0 +1,223 @@
+package com.sercapnp.lang;
+
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Handles Ctrl+Click (Go to Declaration) for Cap'n Proto type references.
+ *
+ * When the user Ctrl+Clicks on a type name like "PersonInfo" or "StatusCode",
+ * this handler finds its struct/enum/interface definition in:
+ *   1. The current file
+ *   2. Imported .capnp files
+ * and navigates the editor to it.
+ */
+public class CapnpGotoDeclarationHandler implements GotoDeclarationHandler {
+
+    // Pattern to find a type definition: struct/enum/interface Name
+    // Captures the entire line so we can get exact offset
+    private static final Pattern TYPE_DEF_LINE = Pattern.compile(
+            "^(\\s*)(struct|enum|interface)\\s+(%s)\\b",
+            Pattern.MULTILINE
+    );
+
+    // Pattern to find: const name
+    private static final Pattern CONST_DEF_LINE = Pattern.compile(
+            "^(\\s*)const\\s+(%s)\\b",
+            Pattern.MULTILINE
+    );
+
+    // Pattern to find: annotation name
+    private static final Pattern ANNOTATION_DEF_LINE = Pattern.compile(
+            "^(\\s*)annotation\\s+(%s)\\b",
+            Pattern.MULTILINE
+    );
+
+    // Pattern to find enum enumerant: name @N
+    private static final Pattern ENUMERANT_LINE = Pattern.compile(
+            "^(\\s+)(%s)\\s+@\\d+",
+            Pattern.MULTILINE
+    );
+
+    @Override
+    public PsiElement @Nullable [] getGotoDeclarationTargets(@Nullable PsiElement sourceElement,
+                                                              int offset,
+                                                              Editor editor) {
+        if (sourceElement == null) return null;
+
+        PsiFile file = sourceElement.getContainingFile();
+        if (file == null || !(file instanceof CapnpFile)) return null;
+
+        // Get the identifier text under the cursor
+        String name = getIdentifierAt(file.getText(), offset);
+        if (name == null || name.isEmpty()) return null;
+
+        // Skip built-in types — no definition to navigate to
+        if (isBuiltinType(name)) return null;
+
+        Project project = file.getProject();
+
+        // 1. Search in current file
+        PsiElement found = findDefinition(file, name);
+        if (found != null) return new PsiElement[]{found};
+
+        // 2. Search in imported files
+        CapnpSchemaScanner.ScanResult scan = CapnpSchemaScanner.scan(file.getText());
+
+        VirtualFile vFile = file.getVirtualFile();
+        if (vFile == null && file.getOriginalFile() != null) {
+            vFile = file.getOriginalFile().getVirtualFile();
+        }
+
+        for (CapnpSchemaScanner.ImportInfo imp : scan.imports) {
+            VirtualFile imported = CapnpSchemaScanner.resolveImport(vFile, imp.path, project);
+            if (imported == null) continue;
+
+            PsiFile importedPsi = PsiManager.getInstance(project).findFile(imported);
+            if (importedPsi == null) continue;
+
+            // If the import has an alias and the name matches the alias,
+            // and there's a specific type, resolve to that type
+            if (imp.alias != null && imp.alias.equals(name) && imp.specificType != null) {
+                PsiElement target = findDefinition(importedPsi, imp.specificType);
+                if (target != null) return new PsiElement[]{target};
+            }
+
+            // Try finding the name directly in the imported file
+            PsiElement target = findDefinition(importedPsi, name);
+            if (target != null) return new PsiElement[]{target};
+        }
+
+        // 3. Fallback: search all .capnp files in project
+        for (VirtualFile capnpFile : com.intellij.psi.search.FileTypeIndex.getFiles(
+                CapnpFileType.INSTANCE,
+                com.intellij.psi.search.GlobalSearchScope.allScope(project))) {
+
+            if (capnpFile.equals(file.getVirtualFile())) continue;
+
+            PsiFile psi = PsiManager.getInstance(project).findFile(capnpFile);
+            if (psi == null) continue;
+
+            PsiElement target = findDefinition(psi, name);
+            if (target != null) return new PsiElement[]{target};
+        }
+
+        return null;
+    }
+
+    /**
+     * Find the PsiElement at the definition of 'name' in the given file.
+     * Returns the PsiElement at the name's offset, or null.
+     */
+    private PsiElement findDefinition(PsiFile file, String name) {
+        String text = file.getText();
+        String escaped = Pattern.quote(name);
+
+        // Try struct/enum/interface
+        int nameOffset = findNameOffset(text, TYPE_DEF_LINE, escaped, name);
+        if (nameOffset >= 0) {
+            return file.findElementAt(nameOffset);
+        }
+
+        // Try const
+        nameOffset = findNameOffset(text, CONST_DEF_LINE, escaped, name);
+        if (nameOffset >= 0) {
+            return file.findElementAt(nameOffset);
+        }
+
+        // Try annotation
+        nameOffset = findNameOffset(text, ANNOTATION_DEF_LINE, escaped, name);
+        if (nameOffset >= 0) {
+            return file.findElementAt(nameOffset);
+        }
+
+        // Try enum enumerant
+        nameOffset = findNameOffset(text, ENUMERANT_LINE, escaped, name);
+        if (nameOffset >= 0) {
+            return file.findElementAt(nameOffset);
+        }
+
+        return null;
+    }
+
+    /**
+     * Find the character offset of 'name' in a pattern match.
+     *
+     * @param text     File text
+     * @param template Pattern template with %s placeholder for the name
+     * @param escaped  Regex-escaped name
+     * @param name     Raw name string
+     * @return offset of the name, or -1
+     */
+    private int findNameOffset(String text, Pattern template, String escaped, String name) {
+        // Build the actual pattern by formatting the name into the template
+        Pattern pattern = Pattern.compile(
+                String.format(template.pattern(), escaped),
+                template.flags()
+        );
+        Matcher m = pattern.matcher(text);
+        if (m.find()) {
+            // Find the exact position of the name within the match
+            int matchStart = m.start();
+            int namePos = text.indexOf(name, matchStart);
+            if (namePos >= matchStart && namePos <= m.end()) {
+                return namePos;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Extract the identifier at the given offset.
+     */
+    private String getIdentifierAt(String text, int offset) {
+        if (offset < 0 || offset >= text.length()) return null;
+
+        // Find word boundaries
+        int start = offset;
+        int end = offset;
+
+        while (start > 0 && isIdentChar(text.charAt(start - 1))) start--;
+        while (end < text.length() && isIdentChar(text.charAt(end))) end++;
+
+        if (start == end) return null;
+
+        String word = text.substring(start, end);
+
+        // Must start with a letter
+        if (word.isEmpty() || !Character.isLetter(word.charAt(0))) return null;
+
+        return word;
+    }
+
+    private boolean isIdentChar(char c) {
+        return Character.isLetterOrDigit(c) || c == '_';
+    }
+
+    private boolean isBuiltinType(String name) {
+        switch (name) {
+            case "Void": case "Bool":
+            case "Int8": case "Int16": case "Int32": case "Int64":
+            case "UInt8": case "UInt16": case "UInt32": case "UInt64":
+            case "Float32": case "Float64":
+            case "Text": case "Data": case "List": case "AnyPointer":
+            // Keywords
+            case "struct": case "enum": case "interface": case "union":
+            case "group": case "import": case "using": case "const":
+            case "annotation": case "extends":
+            case "true": case "false": case "void": case "inf": case "nan":
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/src/main/java/com/sercapnp/lang/CapnpOrdinalTypedHandler.java
+++ b/src/main/java/com/sercapnp/lang/CapnpOrdinalTypedHandler.java
@@ -1,0 +1,299 @@
+package com.sercapnp.lang;
+
+import com.intellij.codeInsight.editorActions.TypedHandlerDelegate;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Auto-inserts the next ordinal number when '@' is typed in a field/enumerant position.
+ *
+ * Behavior:
+ *   - User types field name, then '@'
+ *   - Handler detects we're inside a struct/enum/interface/union block
+ *   - Finds the highest existing @N ordinal in the current scope
+ *   - Replaces the typed '@' with '@(N+1)'
+ *
+ * Does NOT trigger when:
+ *   - At line start (might be a file ID like @0xABCD)
+ *   - After '=' or ':' (value/type context)
+ *   - Outside of any block (brace depth 0)
+ *   - Inside a comment or string
+ */
+public class CapnpOrdinalTypedHandler extends TypedHandlerDelegate {
+
+    // Matches @N ordinals in text
+    private static final Pattern ORDINAL_PATTERN = Pattern.compile("@(\\d+)");
+
+    @NotNull
+    @Override
+    public Result charTyped(char c, @NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file) {
+        if (c != '@') return Result.CONTINUE;
+        if (!(file instanceof CapnpFile)) return Result.CONTINUE;
+
+        Document doc = editor.getDocument();
+        int offset = editor.getCaretModel().getOffset();
+        String text = doc.getText();
+
+        // The '@' has already been inserted at offset-1
+        int atPos = offset - 1;
+        if (atPos < 0) return Result.CONTINUE;
+
+        // Check context: should we auto-insert ordinal?
+        if (!shouldAutoInsert(text, atPos)) {
+            return Result.CONTINUE;
+        }
+
+        // Find the enclosing block boundaries
+        int blockStart = findBlockStart(text, atPos);
+        if (blockStart < 0) return Result.CONTINUE;
+
+        int blockEnd = findBlockEnd(text, atPos);
+        if (blockEnd < 0) blockEnd = text.length();
+
+        // Find highest ordinal in the current block
+        int maxOrdinal = findMaxOrdinal(text, blockStart, blockEnd);
+        int nextOrdinal = maxOrdinal + 1;
+
+        // Insert the ordinal number right after '@'
+        String ordinalStr = Integer.toString(nextOrdinal);
+        doc.insertString(offset, ordinalStr);
+
+        // Move caret after the inserted number
+        editor.getCaretModel().moveToOffset(offset + ordinalStr.length());
+
+        return Result.STOP;
+    }
+
+    /**
+     * Determine if we should auto-insert an ordinal at this position.
+     */
+    private boolean shouldAutoInsert(String text, int atPos) {
+        // Must be inside a block (brace depth > 0)
+        int braceDepth = countBraceDepth(text, atPos);
+        if (braceDepth <= 0) return false;
+
+        // Check what's before the '@' (skip whitespace)
+        int pos = atPos - 1;
+        while (pos >= 0 && (text.charAt(pos) == ' ' || text.charAt(pos) == '\t')) {
+            pos--;
+        }
+
+        if (pos < 0) return false;
+
+        char prevChar = text.charAt(pos);
+
+        // The '@' should come after an identifier (field name / enum value / method name)
+        if (!Character.isLetterOrDigit(prevChar) && prevChar != '_') {
+            return false;
+        }
+
+        // Walk back through the identifier
+        while (pos >= 0 && (Character.isLetterOrDigit(text.charAt(pos)) || text.charAt(pos) == '_')) {
+            pos--;
+        }
+
+        // Now pos is at the character before the identifier.
+        // Skip whitespace again
+        while (pos >= 0 && (text.charAt(pos) == ' ' || text.charAt(pos) == '\t')) {
+            pos--;
+        }
+
+        if (pos < 0) return false;
+
+        char beforeIdent = text.charAt(pos);
+
+        // Valid contexts for ordinal:
+        // - After newline or '{' → field/enumerant at start of line (inside block)
+        // - After ';' → next field
+        // These indicate we're at a field/enumerant declaration position
+        if (beforeIdent == '\n' || beforeIdent == '\r' || beforeIdent == '{' || beforeIdent == ';') {
+            return true;
+        }
+
+        // Also check: if the identifier is preceded by ')' that could be method params
+        // e.g., method name @N (...) -> (...)
+        // But typically in capnp: methodName @N (params) -> (results)
+        // so '@' comes right after the name, same as fields
+
+        return false;
+    }
+
+    /**
+     * Find the start of the enclosing block (the '{' that opens the current scope).
+     */
+    private int findBlockStart(String text, int pos) {
+        int depth = 0;
+        boolean inString = false;
+        boolean inComment = false;
+
+        for (int i = pos - 1; i >= 0; i--) {
+            char c = text.charAt(i);
+
+            // Handle reverse scanning through comments (tricky — skip to line start for #)
+            if (c == '\n') {
+                inComment = false;
+                continue;
+            }
+
+            if (inString) {
+                if (c == '"' && (i == 0 || text.charAt(i - 1) != '\\')) {
+                    inString = false;
+                }
+                continue;
+            }
+
+            // Check if this line has a # comment — if so, skip if we're after #
+            if (c == '#') {
+                inComment = true;
+                continue;
+            }
+            if (inComment) continue;
+
+            if (c == '"') {
+                inString = true;
+                continue;
+            }
+
+            if (c == '}') {
+                depth++;
+            } else if (c == '{') {
+                if (depth == 0) {
+                    return i;
+                }
+                depth--;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Find the end of the enclosing block (the '}' that closes the current scope).
+     */
+    private int findBlockEnd(String text, int pos) {
+        int depth = 0;
+        boolean inString = false;
+        boolean inComment = false;
+
+        for (int i = pos; i < text.length(); i++) {
+            char c = text.charAt(i);
+
+            if (inComment) {
+                if (c == '\n') inComment = false;
+                continue;
+            }
+
+            if (inString) {
+                if (c == '\\') { i++; continue; }
+                if (c == '"') inString = false;
+                continue;
+            }
+
+            if (c == '#') { inComment = true; continue; }
+            if (c == '"') { inString = true; continue; }
+
+            if (c == '{') {
+                depth++;
+            } else if (c == '}') {
+                if (depth == 0) return i;
+                depth--;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Find the maximum ordinal @N within the given text range.
+     * Only looks at the current block level (skips nested blocks).
+     */
+    private int findMaxOrdinal(String text, int start, int end) {
+        int maxOrdinal = -1;
+        int depth = 0;
+        boolean inString = false;
+        boolean inComment = false;
+
+        // Start after the opening '{'
+        int searchStart = start + 1;
+
+        for (int i = searchStart; i < end && i < text.length(); i++) {
+            char c = text.charAt(i);
+
+            if (inComment) {
+                if (c == '\n') inComment = false;
+                continue;
+            }
+
+            if (inString) {
+                if (c == '\\') { i++; continue; }
+                if (c == '"') inString = false;
+                continue;
+            }
+
+            if (c == '#') { inComment = true; continue; }
+            if (c == '"') { inString = true; continue; }
+
+            if (c == '{') { depth++; continue; }
+            if (c == '}') { depth--; continue; }
+
+            // Only look at ordinals at the current block level (depth 0)
+            // But ALSO look inside unions/groups at depth 1,
+            // because capnp ordinals share the same numbering space within a struct
+            if (depth <= 1 && c == '@' && i + 1 < end) {
+                // Check if this is @N (ordinal) not @0x... (type ID)
+                int numStart = i + 1;
+                if (numStart < end && Character.isDigit(text.charAt(numStart))) {
+                    int numEnd = numStart;
+                    while (numEnd < end && Character.isDigit(text.charAt(numEnd))) {
+                        numEnd++;
+                    }
+                    // Make sure it's not @0x... (hex ID)
+                    if (numEnd < end && (text.charAt(numEnd) == 'x' || text.charAt(numEnd) == 'X')) {
+                        continue; // This is a hex ID, skip
+                    }
+                    try {
+                        int ordinal = Integer.parseInt(text.substring(numStart, numEnd));
+                        if (ordinal > maxOrdinal) {
+                            maxOrdinal = ordinal;
+                        }
+                    } catch (NumberFormatException e) {
+                        // ignore
+                    }
+                }
+            }
+        }
+
+        return maxOrdinal;
+    }
+
+    private int countBraceDepth(String text, int offset) {
+        int depth = 0;
+        boolean inString = false;
+        boolean inComment = false;
+
+        for (int i = 0; i < offset && i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (inComment) {
+                if (c == '\n') inComment = false;
+                continue;
+            }
+            if (inString) {
+                if (c == '\\') { i++; continue; }
+                if (c == '"') inString = false;
+                continue;
+            }
+            if (c == '#') { inComment = true; continue; }
+            if (c == '"') { inString = true; continue; }
+            if (c == '{') depth++;
+            if (c == '}') depth--;
+        }
+        return depth;
+    }
+}

--- a/src/main/java/com/sercapnp/lang/CapnpSchemaScanner.java
+++ b/src/main/java/com/sercapnp/lang/CapnpSchemaScanner.java
@@ -1,0 +1,436 @@
+package com.sercapnp.lang;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.search.FileTypeIndex;
+import com.intellij.psi.search.GlobalSearchScope;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Scans .capnp files to extract type definitions and resolve imports.
+ * Works without PSI tree — uses regex on file text.
+ */
+public class CapnpSchemaScanner {
+
+    private static final Logger LOG = Logger.getInstance(CapnpSchemaScanner.class);
+
+    // ── Patterns ────────────────────────────────────────────────────────────────
+
+    // Top-level type defs (0-4 spaces indent)
+    private static final Pattern TYPE_DEF_PATTERN = Pattern.compile(
+            "^\\s{0,4}(struct|enum|interface)\\s+([A-Z][A-Za-z0-9]*)\\b",
+            Pattern.MULTILINE
+    );
+
+    // Nested type defs (2+ spaces or tab indent)
+    private static final Pattern NESTED_TYPE_PATTERN = Pattern.compile(
+            "^(?:\\s{2,}|\\t+)(struct|enum|interface)\\s+([A-Z][A-Za-z0-9]*)\\b",
+            Pattern.MULTILINE
+    );
+
+    private static final Pattern CONST_DEF_PATTERN = Pattern.compile(
+            "^\\s*const\\s+([a-zA-Z][A-Za-z0-9]*)\\s*:",
+            Pattern.MULTILINE
+    );
+
+    private static final Pattern ANNOTATION_DEF_PATTERN = Pattern.compile(
+            "^\\s*annotation\\s+([a-zA-Z][A-Za-z0-9]*)\\s",
+            Pattern.MULTILINE
+    );
+
+    // import "path.capnp"
+    private static final Pattern IMPORT_PATTERN = Pattern.compile(
+            "import\\s+\"([^\"]+)\"",
+            Pattern.MULTILINE
+    );
+
+    // using Alias = import "path.capnp".Type
+    private static final Pattern USING_IMPORT_PATTERN = Pattern.compile(
+            "^\\s*using\\s+([A-Z][A-Za-z0-9]*)\\s*=\\s*import\\s+\"([^\"]+)\"(?:\\s*\\.\\s*([A-Z][A-Za-z0-9]*))?",
+            Pattern.MULTILINE
+    );
+
+    // using import "path.capnp".Type;
+    private static final Pattern USING_IMPORT_DIRECT_PATTERN = Pattern.compile(
+            "^\\s*using\\s+import\\s+\"([^\"]+)\"\\s*\\.\\s*([A-Z][A-Za-z0-9]*)",
+            Pattern.MULTILINE
+    );
+
+    // using Alias = Scope.Type
+    private static final Pattern USING_ALIAS_PATTERN = Pattern.compile(
+            "^\\s*using\\s+([A-Z][A-Za-z0-9]*)\\s*=\\s*([A-Z][A-Za-z0-9.]+)",
+            Pattern.MULTILINE
+    );
+
+    // ── Data classes ────────────────────────────────────────────────────────────
+
+    public static class ScanResult {
+        public final List<TypeInfo> types = new ArrayList<>();
+        public final List<String> constants = new ArrayList<>();
+        public final List<String> annotations = new ArrayList<>();
+        public final List<ImportInfo> imports = new ArrayList<>();
+        public final List<AliasInfo> aliases = new ArrayList<>();
+
+        public List<String> allTypeNames() {
+            List<String> names = new ArrayList<>();
+            for (TypeInfo t : types) names.add(t.name);
+            return names;
+        }
+    }
+
+    public static class TypeInfo {
+        public final String kind;
+        public final String name;
+        public final boolean nested;
+
+        public TypeInfo(String kind, String name, boolean nested) {
+            this.kind = kind;
+            this.name = name;
+            this.nested = nested;
+        }
+    }
+
+    public static class ImportInfo {
+        public final String path;
+        public final String alias;
+        public final String specificType;
+
+        public ImportInfo(String path, String alias, String specificType) {
+            this.path = path;
+            this.alias = alias;
+            this.specificType = specificType;
+        }
+    }
+
+    public static class AliasInfo {
+        public final String alias;
+        public final String target;
+
+        public AliasInfo(String alias, String target) {
+            this.alias = alias;
+            this.target = target;
+        }
+    }
+
+    // ── Scanning ────────────────────────────────────────────────────────────────
+
+    public static ScanResult scan(String text) {
+        ScanResult result = new ScanResult();
+        if (text == null || text.isEmpty()) return result;
+
+        String stripped = stripComments(text);
+        Set<String> seenNames = new HashSet<>();
+
+        // Top-level types
+        Matcher m = TYPE_DEF_PATTERN.matcher(stripped);
+        while (m.find()) {
+            String name = m.group(2);
+            if (seenNames.add(name)) {
+                result.types.add(new TypeInfo(m.group(1), name, false));
+            }
+        }
+
+        // Nested types
+        m = NESTED_TYPE_PATTERN.matcher(stripped);
+        while (m.find()) {
+            String name = m.group(2);
+            if (seenNames.add(name)) {
+                result.types.add(new TypeInfo(m.group(1), name, true));
+            }
+        }
+
+        // Constants
+        m = CONST_DEF_PATTERN.matcher(stripped);
+        while (m.find()) result.constants.add(m.group(1));
+
+        // Annotations
+        m = ANNOTATION_DEF_PATTERN.matcher(stripped);
+        while (m.find()) result.annotations.add(m.group(1));
+
+        // === Imports ===
+        Set<String> seenImportPaths = new HashSet<>();
+
+        // using Alias = import "path".Type
+        m = USING_IMPORT_PATTERN.matcher(stripped);
+        while (m.find()) {
+            String path = m.group(2);
+            seenImportPaths.add(path);
+            result.imports.add(new ImportInfo(path, m.group(1), m.group(3)));
+        }
+
+        // using import "path".Type
+        m = USING_IMPORT_DIRECT_PATTERN.matcher(stripped);
+        while (m.find()) {
+            String path = m.group(1);
+            String typeName = m.group(2);
+            if (seenImportPaths.add(path + "." + typeName)) {
+                result.imports.add(new ImportInfo(path, typeName, typeName));
+                result.aliases.add(new AliasInfo(typeName, typeName));
+            }
+        }
+
+        // Plain import "path"
+        m = IMPORT_PATTERN.matcher(stripped);
+        while (m.find()) {
+            String path = m.group(1);
+            if (seenImportPaths.add(path)) {
+                result.imports.add(new ImportInfo(path, null, null));
+            }
+        }
+
+        // using Alias = Scope.Type (non-import)
+        m = USING_ALIAS_PATTERN.matcher(stripped);
+        while (m.find()) {
+            String target = m.group(2);
+            if (!target.contains("import")) {
+                result.aliases.add(new AliasInfo(m.group(1), target));
+            }
+        }
+
+        return result;
+    }
+
+    // ── Import Resolution (multi-strategy) ──────────────────────────────────────
+
+    /**
+     * Resolve an import path. Tries multiple strategies:
+     * 1. Relative to the importing file's directory
+     * 2. Relative to project content roots
+     * 3. Relative to module source roots
+     * 4. Filename-based search across all project .capnp files
+     */
+    public static VirtualFile resolveImport(VirtualFile importingFile, String importPath, Project project) {
+        if (importPath == null || importPath.isEmpty() || project == null) return null;
+
+        // Strategy 1: Relative to current file's directory
+        if (importingFile != null) {
+            VirtualFile dir = importingFile.getParent();
+            if (dir != null) {
+                VirtualFile found = dir.findFileByRelativePath(importPath);
+                if (found != null && found.isValid()) return found;
+            }
+        }
+
+        // Normalize path for remaining strategies
+        String searchPath = importPath.startsWith("/") ? importPath.substring(1) : importPath;
+
+        // Strategy 2: Relative to project content roots
+        for (VirtualFile root : ProjectRootManager.getInstance(project).getContentRoots()) {
+            VirtualFile found = root.findFileByRelativePath(searchPath);
+            if (found != null && found.isValid()) return found;
+        }
+
+        // Strategy 3: Relative to module source roots
+        for (Module module : ModuleManager.getInstance(project).getModules()) {
+            for (VirtualFile sourceRoot : ModuleRootManager.getInstance(module).getSourceRoots()) {
+                VirtualFile found = sourceRoot.findFileByRelativePath(searchPath);
+                if (found != null && found.isValid()) return found;
+            }
+        }
+
+        // Strategy 4: Search all .capnp files by filename / path suffix
+        String targetFilename = importPath;
+        int lastSlash = targetFilename.lastIndexOf('/');
+        if (lastSlash >= 0) targetFilename = targetFilename.substring(lastSlash + 1);
+
+        Collection<VirtualFile> allFiles = FileTypeIndex.getFiles(
+                CapnpFileType.INSTANCE,
+                GlobalSearchScope.allScope(project)  // allScope includes libraries
+        );
+
+        // Try path suffix match first (more precise)
+        for (VirtualFile file : allFiles) {
+            if (file.getPath().endsWith(searchPath)) return file;
+        }
+
+        // Try filename match (less precise but catches more)
+        String finalTarget = targetFilename;
+        for (VirtualFile file : allFiles) {
+            if (file.getName().equals(finalTarget)) return file;
+        }
+
+        LOG.debug("Could not resolve capnp import: " + importPath +
+                " from " + (importingFile != null ? importingFile.getPath() : "null"));
+        return null;
+    }
+
+    // ── High-level collection ───────────────────────────────────────────────────
+
+    public static ScanResult scanFile(VirtualFile file, Project project) {
+        if (file == null || !file.isValid() || project == null) return null;
+        PsiFile psiFile = PsiManager.getInstance(project).findFile(file);
+        if (psiFile == null) return null;
+        return scan(psiFile.getText());
+    }
+
+    /**
+     * Collect all type names visible from the given file.
+     * Resolves imports, follows one level deep.
+     * Falls back to project-wide search if no imports resolve.
+     */
+    public static Set<String> collectVisibleTypes(PsiFile currentFile) {
+        Set<String> types = new LinkedHashSet<>();
+        if (currentFile == null) return types;
+
+        Project project = currentFile.getProject();
+        ScanResult current = scan(currentFile.getText());
+
+        // 1. Current file types
+        for (TypeInfo t : current.types) types.add(t.name);
+
+        // 2. Aliases
+        for (AliasInfo a : current.aliases) types.add(a.alias);
+
+        // 3. Resolve imports
+        VirtualFile vFile = currentFile.getVirtualFile();
+        if (vFile == null && currentFile.getOriginalFile() != null) {
+            vFile = currentFile.getOriginalFile().getVirtualFile();
+        }
+
+        boolean anyImportResolved = false;
+
+        for (ImportInfo imp : current.imports) {
+            VirtualFile imported = resolveImport(vFile, imp.path, project);
+            if (imported == null) continue;
+
+            anyImportResolved = true;
+            ScanResult importedScan = scanFile(imported, project);
+            if (importedScan == null) continue;
+
+            if (imp.specificType != null) {
+                // using import "...".SpecificType — only that type
+                for (TypeInfo t : importedScan.types) {
+                    if (t.name.equals(imp.specificType)) {
+                        types.add(imp.alias != null ? imp.alias : t.name);
+                        break;
+                    }
+                }
+            } else {
+                // Whole-file import — add all top-level types
+                for (TypeInfo t : importedScan.types) {
+                    if (!t.nested) types.add(t.name);
+                }
+                // If there's a module alias, add it too
+                if (imp.alias != null) types.add(imp.alias);
+            }
+        }
+
+        // 4. Fallback: if imports exist but none resolved → project-wide
+        if (!current.imports.isEmpty() && !anyImportResolved) {
+            types.addAll(collectProjectTypes(project));
+        }
+
+        return types;
+    }
+
+    /**
+     * Collect all type names from ALL .capnp files in the project.
+     */
+    public static Set<String> collectProjectTypes(Project project) {
+        Set<String> types = new LinkedHashSet<>();
+        Collection<VirtualFile> files = FileTypeIndex.getFiles(
+                CapnpFileType.INSTANCE,
+                GlobalSearchScope.allScope(project)
+        );
+        for (VirtualFile file : files) {
+            ScanResult scan = scanFile(file, project);
+            if (scan != null) {
+                for (TypeInfo t : scan.types) {
+                    if (!t.nested) types.add(t.name);
+                }
+            }
+        }
+        return types;
+    }
+
+    /**
+     * Collect all annotation names visible from the given file.
+     */
+    public static Set<String> collectVisibleAnnotations(PsiFile currentFile) {
+        Set<String> annots = new LinkedHashSet<>();
+        if (currentFile == null) return annots;
+
+        Project project = currentFile.getProject();
+        ScanResult current = scan(currentFile.getText());
+        annots.addAll(current.annotations);
+
+        VirtualFile vFile = currentFile.getVirtualFile();
+        if (vFile == null && currentFile.getOriginalFile() != null) {
+            vFile = currentFile.getOriginalFile().getVirtualFile();
+        }
+
+        for (ImportInfo imp : current.imports) {
+            VirtualFile imported = resolveImport(vFile, imp.path, project);
+            ScanResult importedScan = scanFile(imported, project);
+            if (importedScan != null) annots.addAll(importedScan.annotations);
+        }
+
+        return annots;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private static String stripComments(String text) {
+        StringBuilder sb = new StringBuilder(text.length());
+        boolean inString = false;
+
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (inString) {
+                sb.append(c);
+                if (c == '\\' && i + 1 < text.length()) {
+                    sb.append(text.charAt(++i));
+                } else if (c == '"') {
+                    inString = false;
+                }
+                continue;
+            }
+            if (c == '"') {
+                inString = true;
+                sb.append(c);
+            } else if (c == '#') {
+                while (i < text.length() && text.charAt(i) != '\n') i++;
+                if (i < text.length()) sb.append('\n');
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    public static List<String> getEnumValues(String text, String enumName) {
+        List<String> values = new ArrayList<>();
+        Pattern p = Pattern.compile(
+                "enum\\s+" + Pattern.quote(enumName) + "\\s*(?:@0x[a-fA-F0-9]+)?\\s*\\{([^}]*)\\}",
+                Pattern.DOTALL);
+        Matcher m = p.matcher(text);
+        if (m.find()) {
+            Matcher em = Pattern.compile("([a-zA-Z][a-zA-Z0-9]*)\\s+@\\d+").matcher(m.group(1));
+            while (em.find()) values.add(em.group(1));
+        }
+        return values;
+    }
+
+    public static List<String> getStructFields(String text, String structName) {
+        List<String> fields = new ArrayList<>();
+        Pattern p = Pattern.compile(
+                "struct\\s+" + Pattern.quote(structName) + "\\s*(?:\\([^)]*\\))?\\s*(?:@0x[a-fA-F0-9]+)?\\s*\\{([^}]*)\\}",
+                Pattern.DOTALL);
+        Matcher m = p.matcher(text);
+        if (m.find()) {
+            Matcher fm = Pattern.compile("([a-z][a-zA-Z0-9]*)\\s+@\\d+\\s*:").matcher(m.group(1));
+            while (fm.find()) fields.add(fm.group(1));
+        }
+        return fields;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.sercapnp</id>
     <name>SerCapnp</name>
-    <version>3.0</version>
+    <version>5.0</version>
     <vendor email="xmonader@gmail.com" url="https://github.com/xmonader">xmonader</vendor>
 
     <description><![CDATA[
@@ -9,6 +9,9 @@
 <p>Full-featured Cap'n Proto (.capnp) schema language support for IntelliJ-based IDEs.</p>
 <h3>Features</h3>
 <ul>
+  <li><b>Go to definition</b> — Ctrl+Click on any type name to jump to its struct/enum/interface definition, even across imported files</li>
+  <li><b>Ordinal auto-increment</b> — type <code>@</code> after a field name and the next ordinal number is inserted automatically</li>
+  <li><b>Code completion</b> — built-in types (UInt64, List, Text...), keywords, user-defined types, imported types, annotation targets, constants</li>
   <li><b>Syntax highlighting</b> — keywords, types, identifiers, strings, numbers, constants, comments, unique IDs, ordinals</li>
   <li><b>Bracket matching</b> — auto-matching for <code>{}</code>, <code>[]</code>, <code>()</code></li>
   <li><b>Comment toggling</b> — use Ctrl+/ to toggle <code>#</code> line comments</li>
@@ -21,6 +24,8 @@
 
     <change-notes><![CDATA[
     <ul>
+      <li><b>5.0</b>: Go to definition (Ctrl+Click cross-file navigation); ordinal auto-increment (@N auto-numbering)</li>
+      <li><b>4.0</b>: Code completion — built-in types, keywords, user-defined types from current file and imports, annotation names/targets, constants, import paths</li>
       <li><b>3.0</b>: Major update — string, number, constant highlighting; comment toggling; brace matching; code folding; AnyPointer type; fixed lexer</li>
       <li><b>2.0</b>: Updated for IntelliJ Platform 2025.1</li>
       <li><b>1.0</b>: Initial release with syntax highlighting and ID generation</li>
@@ -53,6 +58,13 @@
                 language="Capnp"
                 implementationClass="com.sercapnp.lang.CapnpFoldingBuilder"/>
         <colorSettingsPage implementation="com.sercapnp.lang.CapnpColorSettingsPage"/>
+        <completion.contributor
+                language="Capnp"
+                implementationClass="com.sercapnp.lang.CapnpCompletionContributor"/>
+        <gotoDeclarationHandler
+                implementation="com.sercapnp.lang.CapnpGotoDeclarationHandler"/>
+        <typedHandler
+                implementation="com.sercapnp.lang.CapnpOrdinalTypedHandler"/>
     </extensions>
 
     <actions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.sercapnp</id>
     <name>SerCapnp</name>
-    <version>5.0</version>
+    <version>4.0</version>
     <vendor email="xmonader@gmail.com" url="https://github.com/xmonader">xmonader</vendor>
 
     <description><![CDATA[
@@ -24,8 +24,7 @@
 
     <change-notes><![CDATA[
     <ul>
-      <li><b>5.0</b>: Go to definition (Ctrl+Click cross-file navigation); ordinal auto-increment (@N auto-numbering)</li>
-      <li><b>4.0</b>: Code completion — built-in types, keywords, user-defined types from current file and imports, annotation names/targets, constants, import paths</li>
+      <li><b>4.0</b>: Code completion — built-in types, keywords, user-defined types from current file and imports, annotation names/targets, constants, import paths. Go to definition (Ctrl+Click cross-file navigation); ordinal auto-increment (@N auto-numbering)</li>
       <li><b>3.0</b>: Major update — string, number, constant highlighting; comment toggling; brace matching; code folding; AnyPointer type; fixed lexer</li>
       <li><b>2.0</b>: Updated for IntelliJ Platform 2025.1</li>
       <li><b>1.0</b>: Initial release with syntax highlighting and ID generation</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.sercapnp</id>
     <name>SerCapnp</name>
-    <version>4.2</version>
+    <version>4.1</version>
     <vendor email="xmonader@gmail.com" url="https://github.com/xmonader">xmonader</vendor>
 
     <description><![CDATA[
@@ -26,8 +26,8 @@
 
     <change-notes><![CDATA[
     <ul>
-      <li><b>4.2</b>: Shift ordinals down/up — insert or remove fields in the middle with automatic renumbering (Ctrl+Alt+A, S / U)</li>
-      <li><b>4.1</b>: Go to definition (Ctrl+Click cross-file navigation); ordinal auto-increment (@N auto-numbering)</li>
+      <li><b>4.1</b>: Shift ordinals down/up — insert or remove fields in the middle with automatic renumbering (Ctrl+Alt+A, S / U)</li>
+      <li><b>4.0</b>: Go to definition (Ctrl+Click cross-file navigation); ordinal auto-increment (@N auto-numbering)</li>
       <li><b>4.0</b>: Code completion — built-in types, keywords, user-defined types from current file and imports, annotation names/targets, constants, import paths</li>
       <li><b>3.0</b>: Major update — string, number, constant highlighting; comment toggling; brace matching; code folding; AnyPointer type; fixed lexer</li>
       <li><b>2.0</b>: Updated for IntelliJ Platform 2025.1</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.sercapnp</id>
     <name>SerCapnp</name>
-    <version>4.1</version>
+    <version>4.2</version>
     <vendor email="xmonader@gmail.com" url="https://github.com/xmonader">xmonader</vendor>
 
     <description><![CDATA[
@@ -26,8 +26,8 @@
 
     <change-notes><![CDATA[
     <ul>
-      <li><b>6.0</b>: Shift ordinals down/up — insert or remove fields in the middle with automatic renumbering (Ctrl+Alt+A, S / U)</li>
-      <li><b>5.0</b>: Go to definition (Ctrl+Click cross-file navigation); ordinal auto-increment (@N auto-numbering)</li>
+      <li><b>4.2</b>: Shift ordinals down/up — insert or remove fields in the middle with automatic renumbering (Ctrl+Alt+A, S / U)</li>
+      <li><b>4.1</b>: Go to definition (Ctrl+Click cross-file navigation); ordinal auto-increment (@N auto-numbering)</li>
       <li><b>4.0</b>: Code completion — built-in types, keywords, user-defined types from current file and imports, annotation names/targets, constants, import paths</li>
       <li><b>3.0</b>: Major update — string, number, constant highlighting; comment toggling; brace matching; code folding; AnyPointer type; fixed lexer</li>
       <li><b>2.0</b>: Updated for IntelliJ Platform 2025.1</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>com.sercapnp</id>
     <name>SerCapnp</name>
-    <version>4.0</version>
+    <version>4.1</version>
     <vendor email="xmonader@gmail.com" url="https://github.com/xmonader">xmonader</vendor>
 
     <description><![CDATA[
@@ -10,6 +10,8 @@
 <h3>Features</h3>
 <ul>
   <li><b>Go to definition</b> — Ctrl+Click on any type name to jump to its struct/enum/interface definition, even across imported files</li>
+  <li><b>Shift ordinals down</b> — insert a field in the middle: all subsequent ordinals auto-increment (Ctrl+Alt+A, S)</li>
+  <li><b>Shift ordinals up</b> — remove a field from the middle: close the ordinal gap (Ctrl+Alt+A, U)</li>
   <li><b>Ordinal auto-increment</b> — type <code>@</code> after a field name and the next ordinal number is inserted automatically</li>
   <li><b>Code completion</b> — built-in types (UInt64, List, Text...), keywords, user-defined types, imported types, annotation targets, constants</li>
   <li><b>Syntax highlighting</b> — keywords, types, identifiers, strings, numbers, constants, comments, unique IDs, ordinals</li>
@@ -24,7 +26,9 @@
 
     <change-notes><![CDATA[
     <ul>
-      <li><b>4.0</b>: Code completion — built-in types, keywords, user-defined types from current file and imports, annotation names/targets, constants, import paths. Go to definition (Ctrl+Click cross-file navigation); ordinal auto-increment (@N auto-numbering)</li>
+      <li><b>6.0</b>: Shift ordinals down/up — insert or remove fields in the middle with automatic renumbering (Ctrl+Alt+A, S / U)</li>
+      <li><b>5.0</b>: Go to definition (Ctrl+Click cross-file navigation); ordinal auto-increment (@N auto-numbering)</li>
+      <li><b>4.0</b>: Code completion — built-in types, keywords, user-defined types from current file and imports, annotation names/targets, constants, import paths</li>
       <li><b>3.0</b>: Major update — string, number, constant highlighting; comment toggling; brace matching; code folding; AnyPointer type; fixed lexer</li>
       <li><b>2.0</b>: Updated for IntelliJ Platform 2025.1</li>
       <li><b>1.0</b>: Initial release with syntax highlighting and ID generation</li>
@@ -74,6 +78,20 @@
         </action>
         <action id="Capnp.New" class="com.sercapnp.actions.NewFileAction" text="Capnp File" description="Create new Capnp file">
             <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFromTemplate"/>
+        </action>
+        <action id="Capnp.ShiftOrdinalsDown"
+                class="com.sercapnp.actions.ShiftOrdinalsAction"
+                text="Shift Ordinals Down"
+                description="Increment all ordinals after the current line to create a gap for inserting a new field">
+            <keyboard-shortcut first-keystroke="control alt A" second-keystroke="S" keymap="$default"/>
+            <add-to-group group-id="ToolsMenu" anchor="after" relative-to-action="GenerateCapnpID"/>
+        </action>
+        <action id="Capnp.ShiftOrdinalsUp"
+                class="com.sercapnp.actions.UnshiftOrdinalsAction"
+                text="Shift Ordinals Up"
+                description="Decrement all ordinals from the current line onward to close a gap left by a removed field">
+            <keyboard-shortcut first-keystroke="control alt A" second-keystroke="U" keymap="$default"/>
+            <add-to-group group-id="ToolsMenu" anchor="after" relative-to-action="Capnp.ShiftOrdinalsDown"/>
         </action>
     </actions>
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">feat: code completion, go-to-definition, ordinal auto-increment (v3.0 → v4.0)</p>
<p class="font-claude-response-body break-words whitespace-pre-wrap leading-[1.7]">Add three major features to the Cap'n Proto IntelliJ plugin: context-aware code
completion, cross-file Ctrl+Click navigation, and automatic ordinal numbering.
Four new files (1302 LOC total), one modified file (plugin.xml).</p>
<h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">New Files</h2>
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">CapnpSchemaScanner.java</h3>
<p class="font-claude-response-body break-words whitespace-pre-wrap leading-[1.7]">Regex-based scanner that extracts type definitions, constants, annotations,
imports, and using-aliases from .capnp file text. Operates without a PSI tree
— works directly on raw file text with comment stripping to avoid false matches.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Scanning capabilities:</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">Top-level type definitions: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">struct Foo</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">enum Bar</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">interface Baz</code>
(pattern anchored to 0-4 spaces indent to distinguish from nested)</li>
<li class="whitespace-normal break-words pl-2">Nested type definitions: indented struct/enum/interface inside blocks
(2+ spaces or tab indent, deduplicated against top-level)</li>
<li class="whitespace-normal break-words pl-2">Constant definitions: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">const name :Type = value;</code></li>
<li class="whitespace-normal break-words pl-2">Annotation definitions: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">annotation name (...) :Type;</code></li>
<li class="whitespace-normal break-words pl-2">Import paths: plain <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">import "path.capnp"</code></li>
<li class="whitespace-normal break-words pl-2">Using-import with alias: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">using Alias = import "path.capnp".Type</code></li>
<li class="whitespace-normal break-words pl-2">Using-import direct: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">using import "path.capnp".Type</code></li>
<li class="whitespace-normal break-words pl-2">Using-alias (non-import): <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">using Alias = Scope.Type</code></li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Import resolution — 4-strategy cascade:</strong></p>
<ol class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-decimal flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">Relative to the importing file's parent directory</li>
<li class="whitespace-normal break-words pl-2">Relative to project content roots (ProjectRootManager.getContentRoots)</li>
<li class="whitespace-normal break-words pl-2">Relative to module source roots (ModuleRootManager.getSourceRoots)</li>
<li class="whitespace-normal break-words pl-2">Filename/path-suffix search across all .capnp files in the project
(uses GlobalSearchScope.allScope to include library files)</li>
</ol>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Handles absolute paths (leading <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">/</code> stripped), normalizes for all strategies.
Falls back to project-wide type collection when no imports resolve at all.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Additional robustness:</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">stripComments()</code> removes <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">#</code> line comments before regex matching
to prevent false positives inside commented-out code</li>
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">getVirtualFile()</code> null guard: falls back to
<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">getOriginalFile().getVirtualFile()</code> for IntelliJ's in-memory completion
copies where the direct virtual file reference is null</li>
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">allScope(project)</code> instead of <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">projectScope(project)</code> so that .capnp
files from libraries/dependencies are also discoverable</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Data classes:</strong> ScanResult, TypeInfo (kind/name/nested), ImportInfo
(path/alias/specificType), AliasInfo (alias/target).</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Utility methods:</strong> <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">collectVisibleTypes()</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">collectProjectTypes()</code>,
<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">collectVisibleAnnotations()</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">getEnumValues()</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">getStructFields()</code>.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">CapnpCompletionContributor.java</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Context-aware auto-completion registered via <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">completion.contributor</code> extension
point. Analyzes caret position by scanning backwards through the file text to
determine what kind of completion to offer.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Context detection (analyzeContext method):</strong>
Scans backwards from the caret, first skipping any partial identifier the user
is currently typing, then skipping whitespace, to find the preceding token:</p>
<div class="overflow-x-auto w-full px-2 mb-6">
Preceding token | Context | What is offered
-- | -- | --
: | TYPE_POSITION | Built-in types + user/imported types
= | VALUE_POSITION | true, false, void, inf, nan + const refs
$ | ANNOTATION_REF | Annotation names from current file + imports
( after extends | EXTENDS_TYPE | Built-in + user/imported types
( after annotation decl | ANNOTATION_TARGET | struct, field, enum, enumerant, interface, method, param, annotation, const, file, *
( after List or capitalized name | TYPE_POSITION | Built-in types + user/imported types
;, {, } at depth 0 | TOP_LEVEL | struct, enum, interface, const, using, import, annotation
;, {, } at depth > 0 | BODY_LEVEL | union, group, struct, enum, interface, const, using
Line start at depth 0 | TOP_LEVEL | Declaration keywords
Line start at depth > 0 | BODY_LEVEL | Body keywords
Fallback with preceding : on same statement | TYPE_POSITION | Types

</div>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Completion items with insert handlers:</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">List</code> → inserts <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">()</code> and positions caret between parentheses</li>
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">import</code> → inserts <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]"> "";</code> and positions caret between quotes</li>
<li class="whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">struct</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">enum</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">interface</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">const</code> → appends trailing space</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Priority ordering:</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">Built-in types: priority 100</li>
<li class="whitespace-normal break-words pl-2">Keywords: priority 90</li>
<li class="whitespace-normal break-words pl-2">Annotation names: priority 85</li>
<li class="whitespace-normal break-words pl-2">User-defined types: priority 80</li>
<li class="whitespace-normal break-words pl-2">Constants: priority 70</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Built-in type names are deduplicated against user-defined types to avoid
showing <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Text</code> twice when a project also defines a type named <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Text</code>.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">CapnpGotoDeclarationHandler.java</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Implements <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">GotoDeclarationHandler</code> to enable Ctrl+Click (and Ctrl+B)
navigation from type references to their definitions.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Resolution order:</strong></p>
<ol class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-decimal flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">Extract the identifier under the cursor via <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">getIdentifierAt()</code> which
walks forward and backward from the offset to find word boundaries</li>
<li class="whitespace-normal break-words pl-2">Skip built-in types and keywords (no definition to navigate to)</li>
<li class="whitespace-normal break-words pl-2">Search the <strong>current file</strong> for a matching definition using regex patterns
for struct/enum/interface, const, annotation, and enum enumerant</li>
<li class="whitespace-normal break-words pl-2">Search <strong>imported files</strong> — iterates over all ImportInfo entries from
CapnpSchemaScanner, resolves each import path, and searches the resolved
file. Handles aliased imports: if <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">using Foo = import "bar.capnp".Baz</code>,
clicking on <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Foo</code> resolves to the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Baz</code> definition in bar.capnp</li>
<li class="whitespace-normal break-words pl-2"><strong>Fallback</strong>: searches all .capnp files in the project (allScope)</li>
</ol>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Definition matching:</strong>
Uses parameterized regex patterns (TYPE_DEF_LINE, CONST_DEF_LINE,
ANNOTATION_DEF_LINE, ENUMERANT_LINE) where the target name is injected via
<code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Pattern.quote()</code>. After finding a regex match, locates the exact character
offset of the name within the match and returns <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">file.findElementAt(offset)</code>.
IntelliJ then opens that file and positions the cursor at the definition.</p>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">CapnpOrdinalTypedHandler.java</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Implements <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">TypedHandlerDelegate</code> to auto-insert the next ordinal number
when the user types <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@</code> after a field or enumerant name.</p>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Trigger conditions (shouldAutoInsert):</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">Must be inside a block (brace depth &gt; 0)</li>
<li class="whitespace-normal break-words pl-2">The character before <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@</code> (after skipping whitespace) must be the end of
an identifier (field name / enumerant name / method name)</li>
<li class="whitespace-normal break-words pl-2">The character before that identifier must be a newline, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">{</code>, or <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">;</code>
(indicating a declaration position, not a type or value context)</li>
<li class="whitespace-normal break-words pl-2">Does NOT trigger at line start (could be file ID <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@0xABCD</code>), after <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">:</code>
or <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">=</code>, or inside strings/comments</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Scope-aware ordinal search (findMaxOrdinal):</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">Finds the enclosing <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">{</code> via <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">findBlockStart()</code> (walks backwards counting
brace depth, skipping strings and comments)</li>
<li class="whitespace-normal break-words pl-2">Finds the closing <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">}</code> via <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">findBlockEnd()</code> (walks forward)</li>
<li class="whitespace-normal break-words pl-2">Scans the block for all <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@N</code> patterns at depth 0 and depth 1
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">Depth ≤ 1 is intentional: Cap'n Proto ordinals share the same numbering
space across a struct and its unions/groups, so <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@3</code> inside a union
within a struct must be counted when determining the next ordinal for
a field in the same struct</li>
</ul>
</li>
<li class="whitespace-normal break-words pl-2">Explicitly skips <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@0x...</code> hex patterns (type IDs, not ordinals)</li>
<li class="whitespace-normal break-words pl-2">Parses each ordinal number and tracks the maximum</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Insert behavior:</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2">Inserts <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">(max + 1)</code> as a string immediately after the <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@</code> character</li>
<li class="whitespace-normal break-words pl-2">If no ordinals exist in the block, inserts <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">0</code> (first field)</li>
<li class="whitespace-normal break-words pl-2">Moves the caret to after the inserted number</li>
<li class="whitespace-normal break-words pl-2">Returns <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Result.STOP</code> to prevent further handler processing</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Example flow:</p>
<div role="group" aria-label="Code" tabindex="0" class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-100"><div class="sticky opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"><button class="inline-flex
  items-center
  justify-center
  relative
  isolate
  shrink-0
  can-focus
  select-none
  disabled:pointer-events-none
  disabled:opacity-50
  disabled:shadow-none
  disabled:drop-shadow-none border-transparent
          transition
          font-base
          duration-300
          ease-[cubic-bezier(0.165,0.85,0.45,1)] h-8 w-8 rounded-md backdrop-blur-md _fill_10ocf_9 _ghost_10ocf_96" type="button" aria-label="Copy to clipboard" data-state="closed"><div class="relative"><div class="transition-all opacity-100 scale-100" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-100 scale-100" aria-hidden="true" style="flex-shrink: 0;"><path d="M12.5 3A1.5 1.5 0 0 1 14 4.5V6h1.5A1.5 1.5 0 0 1 17 7.5v8a1.5 1.5 0 0 1-1.5 1.5h-8A1.5 1.5 0 0 1 6 15.5V14H4.5A1.5 1.5 0 0 1 3 12.5v-8A1.5 1.5 0 0 1 4.5 3zm1.5 9.5a1.5 1.5 0 0 1-1.5 1.5H7v1.5a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5H14zM4.5 4a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5z"></path></svg></div><div class="absolute inset-0 flex items-center justify-center"><div class="transition-all opacity-0 scale-50" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-0 scale-50" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.188 5.11a.5.5 0 0 1 .752.626l-.056.084-7.5 9a.5.5 0 0 1-.738.033l-3.5-3.5-.064-.078a.501.501 0 0 1 .693-.693l.078.064 3.113 3.113 7.15-8.58z"></path></svg></div></div></div></button></div></div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono);"><code style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono); white-space: pre-wrap;"><span><span>struct Person {
</span></span><span>  name @0 :Text;      # existing
</span><span>  age @1 :UInt32;      # existing
</span><span>  email@               # user types '@' here
</span><span>  email@2              # handler auto-inserts '2', caret after '2'</span></code></pre></div></div>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Nested union example:</p>
<div role="group" aria-label="Code" tabindex="0" class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-100"><div class="sticky opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"><button class="inline-flex
  items-center
  justify-center
  relative
  isolate
  shrink-0
  can-focus
  select-none
  disabled:pointer-events-none
  disabled:opacity-50
  disabled:shadow-none
  disabled:drop-shadow-none border-transparent
          transition
          font-base
          duration-300
          ease-[cubic-bezier(0.165,0.85,0.45,1)] h-8 w-8 rounded-md backdrop-blur-md _fill_10ocf_9 _ghost_10ocf_96" type="button" aria-label="Copy to clipboard" data-state="closed"><div class="relative"><div class="transition-all opacity-100 scale-100" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-100 scale-100" aria-hidden="true" style="flex-shrink: 0;"><path d="M12.5 3A1.5 1.5 0 0 1 14 4.5V6h1.5A1.5 1.5 0 0 1 17 7.5v8a1.5 1.5 0 0 1-1.5 1.5h-8A1.5 1.5 0 0 1 6 15.5V14H4.5A1.5 1.5 0 0 1 3 12.5v-8A1.5 1.5 0 0 1 4.5 3zm1.5 9.5a1.5 1.5 0 0 1-1.5 1.5H7v1.5a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5H14zM4.5 4a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5z"></path></svg></div><div class="absolute inset-0 flex items-center justify-center"><div class="transition-all opacity-0 scale-50" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-0 scale-50" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.188 5.11a.5.5 0 0 1 .752.626l-.056.084-7.5 9a.5.5 0 0 1-.738.033l-3.5-3.5-.064-.078a.501.501 0 0 1 .693-.693l.078.064 3.113 3.113 7.15-8.58z"></path></svg></div></div></div></button></div></div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono);"><code style="color: rgb(234, 236, 240); background: transparent; font-family: var(--font-mono); white-space: pre-wrap;"><span><span>struct Msg {
</span></span><span>  id @0 :UInt64;
</span><span>  union {
</span><span>    text @1 :Text;
</span><span>    data @2 :Data;
</span><span>  }
</span><span>  timestamp@           # auto-inserts '3' (scans union at depth 1)</span></code></pre></div></div>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
